### PR TITLE
feat: msg create group

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,31 @@ Create a `.env` file in the root of the project with the following content:
 USER_MNEMONICS_FILE="path to file with user mnemonics"
 CHAIN_ID="your chain-id here"
 RPC_URL="your rpc url here"
+DENOM=umfx
+AMOUNT=1
+GAS_LIMIT=20000000
+FEE=100000
+CREATE_GROUP_METADATA_SIZE=2048
 ````
 
-where `USER_MNEMONICS_FILE` is the file containing the mnemonics (one per line) of the accounts you want to use for the load test, `CHAIN_ID` is the chain ID of the network you want to test, and `RPC_URL` is the URL of the RPC endpoint of the network you want to test.
+where `USER_MNEMONICS_FILE` is the file containing the mnemonics (one per line) of the accounts you want to use for the load test, 
+      `CHAIN_ID` is the chain ID of the network you want to test, 
+      `RPC_URL` is the URL of the RPC endpoint of the network you want to test, 
+      `DENOM` is the denomination of the token you want to use for the load test, 
+      `AMOUNT` is the amount of tokens to send in each transaction, 
+      `GAS_LIMIT` is the gas limit for each transaction, 
+      `FEE` is the fee for each transaction, and 
+      `CREATE_GROUP_METADATA_SIZE` is the size of the metadata for the group creation transaction.
 
-Tokens will be transferred from a randomly selected account in the `USER_MNEMONICS_FILE` file to another randomly selected account in the same file.
+Two transaction types are supported: `create_group` and `send`. The load tester will randomly select one of the two transaction types for each transaction.
+
+The `send` transaction will transfer tokens from a randomly selected account in the `USER_MNEMONICS_FILE` file to another randomly selected account in the same file.
+The `create_group` transaction will create a group with a randomly selected account in the `USER_MNEMONICS_FILE` file as the group creator and group member. The group metadata will be a random string of size `CREATE_GROUP_METADATA_SIZE` bytes.
 
 The `USER_MNEMONICS_FILE` file can be generated using the `generate_accounts.sh` script in the `scripts` directory.
 
 The `generate_accounts.sh` script will also generate a genesis balance segment for each account in the `USER_MNEMONICS_FILE` file. This segment should be added to the genesis file of the network you want to test. 
+The `fund_accounts.sh` script can be used to fund the accounts with the generated genesis balance segment.
 
 See the tools section below for more information.
 
@@ -82,5 +98,13 @@ The `scripts` directory contains the `generate_accounts.sh` script, which can be
 # The `mnenomics.txt` file will contain the mnemonics of the generated accounts, one per line. 
 # The `genesis_balance.json` file will contain the genesis balance segment for each account.
 ./scripts/generate_accounts.sh -n 25 -m mnemonics.txt -g genesis_balance.json
+```
+
+The `fund_accounts.sh` script can be used to fund the accounts with the generated genesis balance segment.
+
+```bash 
+# Fund the accounts with the generated genesis balance segment
+# The `genesis_balance.json` file will be used to fund the accounts.
+./scripts/fund_accounts.sh genesis_balance.json
 ```
 

--- a/cmd/manifest-load-tester/main.go
+++ b/cmd/manifest-load-tester/main.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	"github.com/joho/godotenv"
 	"github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest"
+	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
 )
 
 const CoinType = 118
@@ -133,6 +134,12 @@ func main() {
 	}
 	gasLimit, err := strconv.ParseUint(gasLimitStr, 10, 64)
 
+	createGroupMetadataSizeStr := os.Getenv("CREATE_GROUP_METADATA_SIZE")
+	if createGroupMetadataSizeStr == "" {
+		panic("CREATE_GROUP_METADATA_SIZE env var not set) }")
+	}
+	createGroupMetadataSize, err := strconv.ParseUint(createGroupMetadataSizeStr, 10, 64)
+
 	types.GetConfig().SetBech32PrefixForAccount("manifest", "manifestpub")
 
 	rpcClient, err := client.NewClientFromNode(rpcUrl)
@@ -171,12 +178,13 @@ func main() {
 		panic("not enough users to pick two random entries")
 	}
 
-	cosmosClientFactory := manifestledgerloadtest.NewCosmosClientFactory(clientCtx, manifestledgerloadtest.Params{
-		Users:    records,
-		Amount:   amount,
-		GasLimit: gasLimit,
-		Denom:    denom,
-		Fee:      fee,
+	cosmosClientFactory := manifestledgerloadtest.NewCosmosClientFactory(clientCtx, manifesttypes.Params{
+		Users:                   records,
+		Amount:                  amount,
+		GasLimit:                gasLimit,
+		Denom:                   denom,
+		Fee:                     fee,
+		CreateGroupMetadataSize: createGroupMetadataSize,
 	})
 	if err := loadtest.RegisterClientFactory("manifest-ledger-load-test", cosmosClientFactory); err != nil {
 		panic(err)

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.1.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
+	github.com/cockroachdb/apd/v2 v2.0.2 // indirect
 	github.com/cockroachdb/errors v1.11.3 // indirect
 	github.com/cockroachdb/fifo v0.0.0-20240606204812-0bbfbd93a7ce // indirect
 	github.com/cockroachdb/logtags v0.0.0-20230118201751-21c54148d20b // indirect

--- a/pkg/manifestledgerloadtest/client.go
+++ b/pkg/manifestledgerloadtest/client.go
@@ -37,8 +37,8 @@ func NewCosmosClientFactory(clientCtx client.Context, params manitesttypes.Param
 		txWeights: make(map[string]int),
 	}
 
-	//cosmosClient.RegisterTxGenerator("bank_send", &txsgen.BankSendTxGenerator{}, 1)
-	cosmosClient.RegisterTxGenerator("create_group", &txsgen.CreateGroupTxGenerator{}, 1)
+	cosmosClient.RegisterTxGenerator("bank_send", &txsgen.BankSendTxGenerator{}, 0.5)
+	cosmosClient.RegisterTxGenerator("create_group", &txsgen.CreateGroupTxGenerator{}, 0.5)
 
 	return cosmosClient
 }

--- a/pkg/manifestledgerloadtest/txs/create_group.go
+++ b/pkg/manifestledgerloadtest/txs/create_group.go
@@ -1,0 +1,38 @@
+package txs
+
+import (
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	grouptypes "github.com/cosmos/cosmos-sdk/x/group"
+	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
+	"github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/utils"
+)
+
+type CreateGroupTxGenerator struct{}
+
+func (g *CreateGroupTxGenerator) GenerateMsg(ctx client.Context, params manifesttypes.Params) (*keyring.Record, types.Msg, error) {
+	userRandomIdx := rand.Perm(len(params.Users))[0:1]
+	r1 := params.Users[userRandomIdx[0]]
+
+	addr1, err := r1.GetAddress()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	msg := &grouptypes.MsgCreateGroup{
+		Admin: addr1.String(),
+		Members: []grouptypes.MemberRequest{
+			{
+				Address:  addr1.String(),
+				Weight:   "1",
+				Metadata: "user",
+			},
+		},
+		Metadata: utils.RandomString(params.CreateGroupMetadataSize),
+	}
+
+	return r1, msg, nil
+}

--- a/pkg/manifestledgerloadtest/txs/generator.go
+++ b/pkg/manifestledgerloadtest/txs/generator.go
@@ -1,0 +1,13 @@
+package txs
+
+import (
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
+)
+
+type TxGenerator interface {
+	// GenerateMsg generates a transaction message
+	GenerateMsg(ctx client.Context, params manifesttypes.Params) (*keyring.Record, types.Msg, error)
+}

--- a/pkg/manifestledgerloadtest/txs/send.go
+++ b/pkg/manifestledgerloadtest/txs/send.go
@@ -1,0 +1,31 @@
+package txs
+
+import (
+	"fmt"
+	"math/rand"
+
+	"github.com/cosmos/cosmos-sdk/client"
+	"github.com/cosmos/cosmos-sdk/crypto/keyring"
+	"github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
+)
+
+type BankSendTxGenerator struct{}
+
+func (g *BankSendTxGenerator) GenerateMsg(ctx client.Context, params manifesttypes.Params) (*keyring.Record, types.Msg, error) {
+	userRandomIdx := rand.Perm(len(params.Users))[0:2]
+	r1 := params.Users[userRandomIdx[0]]
+	r2 := params.Users[userRandomIdx[1]]
+
+	addr1, err := r1.GetAddress()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get address from record 1: %w", err)
+	}
+	addr2, err := r2.GetAddress()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get address from record 2: %w", err)
+	}
+
+	return r1, banktypes.NewMsgSend(addr1, addr2, types.NewCoins(types.NewInt64Coin(params.Denom, params.Amount))), nil
+}

--- a/pkg/manifestledgerloadtest/types/params.go
+++ b/pkg/manifestledgerloadtest/types/params.go
@@ -1,0 +1,12 @@
+package types
+
+import "github.com/cosmos/cosmos-sdk/crypto/keyring"
+
+type Params struct {
+	Users                   []*keyring.Record
+	Fee                     int64
+	Amount                  int64
+	Denom                   string
+	GasLimit                uint64
+	CreateGroupMetadataSize uint64
+}

--- a/pkg/manifestledgerloadtest/utils/random.go
+++ b/pkg/manifestledgerloadtest/utils/random.go
@@ -1,0 +1,13 @@
+package utils
+
+import "math/rand"
+
+const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+
+func RandomString(length uint64) string {
+	b := make([]byte, length)
+	for i := range b {
+		b[i] = charset[rand.Intn(len(charset))]
+	}
+	return string(b)
+}

--- a/scripts/fund_accounts.sh
+++ b/scripts/fund_accounts.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Set the path to your JSON file (passed as a parameter)
+JSON_FILE="$1"
+
+# Set the sender's wallet name
+SENDER="manifest1hj5fveer5cjtn4wd6wstzugjfdxzl0xp8ws9ct"
+NODE="http://localhost:26657"
+
+# Set the chain ID and fees
+CHAIN_ID="manifest-ledger-beta"
+GAS_PRICES="0.0011umfx"
+GAS_ADJUSTMENT="1.4"
+
+# Loop through each balance entry in the JSON file
+jq -c '.[] | .balances[]' $JSON_FILE | while read balance; do
+    # Extract the recipient address, amount, and denomination
+    RECIPIENT_ADDRESS=$(echo $balance | jq -r '.address')
+    AMOUNT=$(echo $balance | jq -r '.coins[0].amount')
+    DENOM=$(echo $balance | jq -r '.coins[0].denom')
+
+    # Construct the amount with the denomination
+    AMOUNT_WITH_DENOM="${AMOUNT}${DENOM}"
+
+    echo "Sending $AMOUNT_WITH_DENOM from $SENDER to $RECIPIENT_ADDRESS : "
+
+    # Run the transaction using manifestd
+    manifestd --node $NODE tx bank send $SENDER $RECIPIENT_ADDRESS $AMOUNT_WITH_DENOM \
+      --chain-id $CHAIN_ID --gas auto --gas-adjustment $GAS_ADJUSTMENT --gas-prices $GAS_PRICES \
+      --keyring-backend test --yes
+
+    # Optionally, sleep for a short time between transactions
+    sleep 5
+done


### PR DESCRIPTION
This PR adds support for `MsgCreateGroup` in addition to the basic `MsgSend`.

`MsgCreateGroup` allows us to test the impact of the maximum group metadata length setting.