### PR TITLE
chore: update gh org and bumps

### DIFF
--- a/cmd/manifest-load-tester/main.go
+++ b/cmd/manifest-load-tester/main.go
@@ -29,8 +29,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/x/slashing"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	"github.com/joho/godotenv"
-	"github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest"
-	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
+	"github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest"
+	manifesttypes "github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/types"
 )
 
 const CoinType = 118

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,12 @@
 module github.com/liftedinit/manifest-load-tester
 
-go 1.23.10
+go 1.24.6
 
-replace github.com/cosmos/cosmos-sdk => github.com/liftedinit/cosmos-sdk v0.50.13-liftedinit.1
+replace github.com/cosmos/cosmos-sdk => github.com/manifest-network/cosmos-sdk v0.50.14-liftedinit.1
 
 require (
 	github.com/cometbft/cometbft-load-test v0.3.0
-	github.com/cosmos/cosmos-sdk v0.50.13
+	github.com/cosmos/cosmos-sdk v0.50.14
 	github.com/joho/godotenv v1.5.1
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/liftedinit/manifest-load-tester
+module github.com/manifest-network/manifest-load-tester
 
 go 1.24.6
 

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,6 @@ github.com/leodido/go-urn v1.2.1 h1:BqpAaACuzVSgi/VLzGZIobT2z4v53pjosyNd9Yv6n/w=
 github.com/leodido/go-urn v1.2.1/go.mod h1:zt4jvISO2HfUBqxjfIshjdMTYS56ZS/qv49ictyFfxY=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/liftedinit/cosmos-sdk v0.50.13-liftedinit.1 h1:z5AmZANrs33wrD2jqbzaE65ITAGRmticOvqTWkJ0ppE=
-github.com/liftedinit/cosmos-sdk v0.50.13-liftedinit.1/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
 github.com/linxGnu/grocksdb v1.8.14 h1:HTgyYalNwBSG/1qCQUIott44wU5b2Y9Kr3z7SK5OfGQ=
@@ -475,6 +473,8 @@ github.com/linxGnu/grocksdb v1.8.14/go.mod h1:QYiYypR2d4v63Wj1adOOfzglnoII0gLj3P
 github.com/lyft/protoc-gen-validate v0.0.13/go.mod h1:XbGvPuh87YZc5TdIa2/I4pLk0QoUACkjt2znoq26NVQ=
 github.com/magiconair/properties v1.8.7 h1:IeQXZAiQcpL9mgcAe1Nu6cX9LLw6ExEHKjN0VQdvPDY=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
+github.com/manifest-network/cosmos-sdk v0.50.14-liftedinit.1 h1:51XJsBI88Ppq0Z+ZEAZhXLUPL1K5gVeIr7GXtlexYTo=
+github.com/manifest-network/cosmos-sdk v0.50.14-liftedinit.1/go.mod h1:hrWEFMU1eoXqLJeE6VVESpJDQH67FS1nnMrQIjO2daw=
 github.com/manifoldco/promptui v0.9.0 h1:3V4HzJk1TtXW1MTZMP7mdlwbBpIinw3HztaIlYthEiA=
 github.com/manifoldco/promptui v0.9.0/go.mod h1:ka04sppxSGFAtxX0qhlYQjISsg9mR4GWtQEhdbn6Pgg=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=

--- a/pkg/manifestledgerloadtest/client.go
+++ b/pkg/manifestledgerloadtest/client.go
@@ -12,9 +12,9 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/tx/signing"
 	authsigning "github.com/cosmos/cosmos-sdk/x/auth/signing"
-	txsgen "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/txs"
-	manitesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
-	"github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/utils"
+	txsgen "github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/txs"
+	manitesttypes "github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/types"
+	"github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/utils"
 )
 import "github.com/cometbft/cometbft-load-test/pkg/loadtest"
 

--- a/pkg/manifestledgerloadtest/txs/create_group.go
+++ b/pkg/manifestledgerloadtest/txs/create_group.go
@@ -7,8 +7,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
 	grouptypes "github.com/cosmos/cosmos-sdk/x/group"
-	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
-	"github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/utils"
+	manifesttypes "github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/types"
+	"github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/utils"
 )
 
 type CreateGroupTxGenerator struct{}

--- a/pkg/manifestledgerloadtest/txs/generator.go
+++ b/pkg/manifestledgerloadtest/txs/generator.go
@@ -4,7 +4,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
-	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
+	manifesttypes "github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/types"
 )
 
 type TxGenerator interface {

--- a/pkg/manifestledgerloadtest/txs/send.go
+++ b/pkg/manifestledgerloadtest/txs/send.go
@@ -8,7 +8,7 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	"github.com/cosmos/cosmos-sdk/types"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-	manifesttypes "github.com/liftedinit/manifest-load-tester/pkg/manifestledgerloadtest/types"
+	manifesttypes "github.com/manifest-network/manifest-load-tester/pkg/manifestledgerloadtest/types"
 )
 
 type BankSendTxGenerator struct{}


### PR DESCRIPTION
This pull request updates the module path, dependencies, and all internal package import paths to use the new `manifest-network` organization instead of `liftedinit`. These changes ensure the project is aligned with the new repository location and dependency sources.

**Repository migration and dependency updates:**

* Changed the module path in `go.mod` from `github.com/liftedinit/manifest-load-tester` to `github.com/manifest-network/manifest-load-tester`, and updated the Go version and related dependency versions to match the new organization.
* Updated all internal import paths throughout the codebase from `github.com/liftedinit/manifest-load-tester/...` to `github.com/manifest-network/manifest-load-tester/...` to reflect the new repository location. [[1]](diffhunk://#diff-7b8a3177d0cf87261f97d0254c4eb8bb93b2e7cdff015516dda6e3186848109dL32-R33) [[2]](diffhunk://#diff-8da853b6378ecaaeaaff36e7b98093c30ed6d9b306f64afab12b35873c16d472L15-R17) [[3]](diffhunk://#diff-18b54d0e46989681ef38e02418938bdc90478d13511f6a12b53bae815a24aa66L10-R11) [[4]](diffhunk://#diff-becc507686bfeb7be186b1e082a25b32bde308576399b1269a274866b3b3ffb3L7-R7) [[5]](diffhunk://#diff-1f78d4fbfb44a7eeb9d1527c6556ef1507587a1da0c888c41611f040e34da1faL11-R11)

**Third-party dependency updates:**

* Updated the `github.com/cosmos/cosmos-sdk` dependency and its replace directive to point to the `manifest-network` fork and to a newer version.